### PR TITLE
main: handle GO111MODULE being set to off in the gobin environment.

### DIFF
--- a/main.go
+++ b/main.go
@@ -286,7 +286,7 @@ func mainerr() error {
 
 			installCmd := exec.Command("go", "install", mp.ImportPath)
 			installCmd.Dir = pkg.wd
-			installCmd.Env = append(os.Environ(), "GOBIN="+gobin, "GOPROXY="+proxy)
+			installCmd.Env = append(os.Environ(), "GO111MODULE=on", "GOBIN="+gobin, "GOPROXY="+proxy)
 			installCmd.Stdout = &stdout
 			installCmd.Stderr = &stderr
 
@@ -380,9 +380,9 @@ var (
 // version this is returned. Otherwise the main packages matched by the
 // packages are populated into a.mainPkgs
 func (a *arg) get(proxy string) error {
-	var env []string
+	env := append(os.Environ(), "GO111MODULE=on")
 	if proxy != "" {
-		env = append(os.Environ(), proxy)
+		env = append(env, proxy)
 	}
 
 	getCmd := exec.Command("go", "get", "-d", a.patt)
@@ -401,9 +401,9 @@ func (a *arg) get(proxy string) error {
 }
 
 func (a *arg) list(proxy string) error {
-	var env []string
+	env := append(os.Environ(), "GO111MODULE=on")
 	if proxy != "" {
-		env = append(os.Environ(), proxy)
+		env = append(env, proxy)
 	}
 
 	var stdout, stderr bytes.Buffer

--- a/testdata/go111module.txt
+++ b/testdata/go111module.txt
@@ -1,0 +1,11 @@
+# Verify that gobin behaves correctly irrespective of the user's setting of GO111MODULE
+
+env HOME=$WORK/home
+env GO111MODULE=off
+gobin -p github.com/gobin-testrepos/simple-main@v1.0.0
+stdout ^$WORK/home/.cache/gobin/github.com/gobin-testrepos/simple-main/@v/v1.0.0/github.com/gobin-testrepos/simple-main/simple-main'$'
+! stderr .+
+
+exec $WORK/home/.cache/gobin/github.com/gobin-testrepos/simple-main/@v/v1.0.0/github.com/gobin-testrepos/simple-main/simple-main
+stdout '^Simple module-based main v1.0.0$'
+! stderr .+


### PR DESCRIPTION
If the caller of gobin as GO111MODULE=off set for whatever reason, we
were previously passing this value through to the go commands that gobin
calls. Given we do everything in a module-aware mode, this is not the
correct behaviour. Hence we need to explicitly set GO111MODULE=on.