### PR TITLE
main: ensure replace directives are applied for non-'-m' installs.

### DIFF
--- a/testdata/mod/github.com_gobin-testrepos_food_v1.0.0.txt
+++ b/testdata/mod/github.com_gobin-testrepos_food_v1.0.0.txt
@@ -1,0 +1,10 @@
+-- .mod --
+module github.com/gobin-testrepos/food
+-- .info --
+{"Version":"v1.0.0","Time":"2018-10-22T18:45:39Z"}
+-- go.mod --
+module github.com/gobin-testrepos/food
+-- main.go --
+package food
+
+const MainCourse = "fish"

--- a/testdata/mod/github.com_gobin-testrepos_foodsubst_v1.0.0.txt
+++ b/testdata/mod/github.com_gobin-testrepos_foodsubst_v1.0.0.txt
@@ -1,0 +1,10 @@
+-- .mod --
+module github.com/gobin-testrepos/food
+-- .info --
+{"Version":"v1.0.0","Time":"2018-10-22T18:45:39Z"}
+-- go.mod --
+module github.com/gobin-testrepos/food
+-- main.go --
+package food
+
+const MainCourse = "chips"

--- a/testdata/mod/github.com_gobin-testrepos_simple-main_v1.0.0.txt
+++ b/testdata/mod/github.com_gobin-testrepos_simple-main_v1.0.0.txt
@@ -1,16 +1,27 @@
-module github.com/gobin-testrepos/simple-main@v1.0.0
-
 -- .mod --
 module github.com/gobin-testrepos/simple-main
+
+require github.com/gobin-testrepos/food v1.0.0
+
+replace github.com/gobin-testrepos/food => github.com/gobin-testrepos/foodsubst v1.0.0
 -- .info --
 {"Version":"v1.0.0","Time":"2018-10-22T18:45:39Z"}
+
 -- go.mod --
 module github.com/gobin-testrepos/simple-main
+
+require github.com/gobin-testrepos/food v1.0.0
+
+replace github.com/gobin-testrepos/food => github.com/gobin-testrepos/foodsubst v1.0.0
+
 -- main.go --
 package main
 
 import "fmt"
 
+import "github.com/gobin-testrepos/food"
+
 func main() {
 	fmt.Println("Simple module-based main v1.0.0")
+	fmt.Printf("Today we will eat %v\n", food.MainCourse)
 }

--- a/testdata/replace-main-mod.txt
+++ b/testdata/replace-main-mod.txt
@@ -1,0 +1,12 @@
+# When we supply -m, then we will _not_ get any replace statements that
+# are present in the main package's module's go.mod
+
+env HOME=$WORK/home
+
+cd repo
+gobin -m -run github.com/gobin-testrepos/simple-main@v1.0.0
+stdout '^Simple module-based main v1.0.0$'
+stdout '^Today we will eat fish$'
+
+-- repo/go.mod --
+module example.com/repo

--- a/testdata/replace.txt
+++ b/testdata/replace.txt
@@ -1,0 +1,8 @@
+# Verify that replace statements in the main package's module are
+# applied when the main package is installed (note, this is not
+# the expectation with -m)
+
+env HOME=$WORK/home
+gobin -run github.com/gobin-testrepos/simple-main@v1.0.0
+stdout '^Simple module-based main v1.0.0$'
+stdout '^Today we will eat chips$'


### PR DESCRIPTION
We were previously, erroneously, not applying replace directives from
the main package's module's go.mod file for non-'-m' installs. When
calling gobin with -m, it is expected that such replace directives are
not applied. But without -m, we effectively treat the main package's
module as the main module (except that we actually treat it as a
dependency, in order to capture the version information in the resulting
binary).

This commit fixes that discrepancy, and locks it in with a two tests,
that compare the presence or otherwise of the replace directive between
the non-'-m' and -m modes.