### PR TITLE
main: add -parseFlags flag, undocumented

### DIFF
--- a/testdata/parseflags.txt
+++ b/testdata/parseflags.txt
@@ -1,0 +1,15 @@
+gobin -parseFlags -run -m example.com/blah input
+! stderr .+
+cmp stdout output.golden
+
+-- output.golden --
+{
+  "Mode": "run",
+  "Patterns": [
+    "example.com/blah"
+  ],
+  "Args": [
+    "input"
+  ],
+  "MainModResolve": true
+}


### PR DESCRIPTION
Rather than creating a package that exposes gobin's flag set and a
function for creating such a flag set, we instead add a flag to gobin
which outputs a JSON blob representing the useful parsed flag state.