### PR TITLE
main: do not print *exec.ExitError for -run

### DIFF
--- a/exitcode_plan9.go
+++ b/exitcode_plan9.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+// ExitCode returns the exit code of the exited process, or -1
+// if the process hasn't exited or was terminated by a signal.
+func ExitCode(p *os.ProcessState) int {
+	// return -1 if the process hasn't started.
+	if p == nil {
+		return -1
+	}
+	return p.Sys().(syscall.WaitStatus).ExitStatus()
+}

--- a/exitcode_posix.go
+++ b/exitcode_posix.go
@@ -1,0 +1,18 @@
+// +build darwin dragonfly freebsd js,wasm linux nacl netbsd openbsd solaris windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+// ExitCode returns the exit code of the exited process, or -1
+// if the process hasn't exited or was terminated by a signal.
+func ExitCode(p *os.ProcessState) int {
+	// return -1 if the process hasn't started.
+	if p == nil {
+		return -1
+	}
+	return p.Sys().(syscall.WaitStatus).ExitStatus()
+}

--- a/main.go
+++ b/main.go
@@ -54,6 +54,9 @@ func main() {
 
 func main1() int {
 	if err := mainerr(); err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			return ExitCode(ee.ProcessState)
+		}
 		fmt.Fprintln(os.Stderr, err)
 		return 1
 	}

--- a/testdata/failing_run.txt
+++ b/testdata/failing_run.txt
@@ -1,5 +1,5 @@
 ! gobin -run example.com/fail
 stdout '^This will fail$'
-stderr '^exit status 42$'
+stderr '^It''s bad$'
 
 

--- a/testdata/mod/example.com_fail_v1.0.0.txt
+++ b/testdata/mod/example.com_fail_v1.0.0.txt
@@ -14,6 +14,7 @@ import "fmt"
 import "os"
 
 func main() {
-  fmt.Println("This will fail")
-  os.Exit(42)
+	fmt.Println("This will fail")
+	fmt.Fprintln(os.Stderr, "It's bad")
+	os.Exit(42)
 }


### PR DESCRIPTION
Instead, rely on the program to output something sensible on
stdout/stderr