### PR TITLE
correctly use executable name when v2+ major version is used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.bin
 /release
+/gobin

--- a/main.go
+++ b/main.go
@@ -314,7 +314,12 @@ func mainerr() error {
 			}
 
 			gobin := filepath.Join(gobinCache, mainrel)
-			target := filepath.Join(gobin, path.Base(mp.ImportPath))
+			pref, _, ok := module.SplitPathVersion(mp.ImportPath)
+			if !ok {
+				return fmt.Errorf("failed to derive non-version prefix from %v", mp.ImportPath)
+			}
+			base := path.Base(pref)
+			target := filepath.Join(gobin, base)
 
 			if runtime.GOOS == "windows" {
 				target += ".exe"

--- a/testdata/major_version.txt
+++ b/testdata/major_version.txt
@@ -1,0 +1,7 @@
+# A test to ensure that where a major version (>=2) exists
+# at the end of the main package path that we end up with
+# the right binary name
+
+gobin -p example.com/good/v2
+stdout [/\\]good$exe$
+! stderr .+

--- a/testdata/mod/example.com_good_v2_v2.0.0.txt
+++ b/testdata/mod/example.com_good_v2_v2.0.0.txt
@@ -1,0 +1,13 @@
+-- .mod --
+module example.com/good/v2
+
+-- .info --
+{"Version":"v2.0.0","Time":"2018-10-22T18:45:39Z"}
+
+-- go.mod --
+module example.com/good/v2
+
+-- main.go --
+package main
+
+func main() {}


### PR DESCRIPTION
When a major version (e.g. github.com/maxbrunsfelt/counterfeiter/v6) is used, `gobin` incorrectly attempts to use `v6` as the binary name, rather than `counterfeiter`. 

This is most likely due to a bug that existed prior to `go 1.12.1`, whereby in this situation the executable was actually called `v6`.

This PR ensures `counterfeiter` is used as the executable name in this situation. It also ignores any built `gobin` binary in the repository root.

The following repo can be used to both see the issue and the efficacy of the fix: https://github.com/joefitzgerald/veesixissue