### PR TITLE
main: fix gopkg.in path handling

### DIFF
--- a/testdata/download.txt
+++ b/testdata/download.txt
@@ -1,7 +1,7 @@
 gobin -d github.com/gobin-testrepos/simple-main@v1.0.0
 ! stdout .+
 ! stderr .+
-[linux]   exists $HOME/.cache/gobin/github.com/gobin-testrepos/simple-main/@v/v1.0.0/github.com/gobin-testrepos/simple-main/simple-main
-[darwin]  exists $HOME/Library/Caches/gobin/github.com/gobin-testrepos/simple-main/@v/v1.0.0/github.com/gobin-testrepos/simple-main/simple-main
-[windows] exists $LOCALAPPDATA/gobin/github.com/gobin-testrepos/simple-main/@v/v1.0.0/github.com/gobin-testrepos/simple-main/simple-main.exe
+[linux]   exists $HOME/.cache/gobin/github.com/gobin-testrepos/simple-main/@v/v1.0.0/simple-main
+[darwin]  exists $HOME/Library/Caches/gobin/github.com/gobin-testrepos/simple-main/@v/v1.0.0/simple-main
+[windows] exists $LOCALAPPDATA/gobin/github.com/gobin-testrepos/simple-main/@v/v1.0.0/simple-main.exe
 

--- a/testdata/go111module.txt
+++ b/testdata/go111module.txt
@@ -2,13 +2,13 @@
 
 env GO111MODULE=off
 gobin -p github.com/gobin-testrepos/simple-main@v1.0.0
-[linux]   stdout ^$HOME\Q/.cache/gobin/github.com/gobin-testrepos/simple-main/@v/v1.0.0/github.com/gobin-testrepos/simple-main/simple-main\E'$'
-[darwin]  stdout ^$HOME\Q/Library/Caches/gobin/github.com/gobin-testrepos/simple-main/@v/v1.0.0/github.com/gobin-testrepos/simple-main/simple-main\E'$'
-[windows] stdout ^${LOCALAPPDATA@R}\Q\gobin\github.com\gobin-testrepos\simple-main\@v\v1.0.0\github.com\gobin-testrepos\simple-main\simple-main.exe\E'$'
+[linux]   stdout ^$HOME\Q/.cache/gobin/github.com/gobin-testrepos/simple-main/@v/v1.0.0/simple-main\E'$'
+[darwin]  stdout ^$HOME\Q/Library/Caches/gobin/github.com/gobin-testrepos/simple-main/@v/v1.0.0/simple-main\E'$'
+[windows] stdout ^${LOCALAPPDATA@R}\Q\gobin\github.com\gobin-testrepos\simple-main\@v\v1.0.0\simple-main.exe\E'$'
 ! stderr .+
 
-[linux]   exec $HOME/.cache/gobin/github.com/gobin-testrepos/simple-main/@v/v1.0.0/github.com/gobin-testrepos/simple-main/simple-main
-[darwin]  exec $HOME/Library/Caches/gobin/github.com/gobin-testrepos/simple-main/@v/v1.0.0/github.com/gobin-testrepos/simple-main/simple-main
-[windows] exec $LOCALAPPDATA/gobin/github.com/gobin-testrepos/simple-main/@v/v1.0.0/github.com/gobin-testrepos/simple-main/simple-main.exe
+[linux]   exec $HOME/.cache/gobin/github.com/gobin-testrepos/simple-main/@v/v1.0.0/simple-main
+[darwin]  exec $HOME/Library/Caches/gobin/github.com/gobin-testrepos/simple-main/@v/v1.0.0/simple-main
+[windows] exec $LOCALAPPDATA/gobin/github.com/gobin-testrepos/simple-main/@v/v1.0.0/simple-main.exe
 stdout '^Simple module-based main v1.0.0$'
 ! stderr .+

--- a/testdata/gopkg.in.txt
+++ b/testdata/gopkg.in.txt
@@ -1,0 +1,14 @@
+# Test that we have the correct logic for gopkg.in paths
+# per https://github.com/myitcv/gobin/issues/65
+
+gobin -p gopkg.in/src-d/go-kallax.v1/generator/cli/kallax
+[linux]   stdout ^$HOME\Q/.cache/gobin/gopkg.in/src-d/go-kallax.v1/@v/v1.3.5/generator/cli/kallax/kallax\E'$'
+[darwin]  stdout ^$HOME\Q/Library/Caches/gobin/gopkg.in/src-d/go-kallax.v1/@v/v1.3.5/generator/cli/kallax/kallax\E'$'
+[windows] stdout ^${LOCALAPPDATA@R}\Q\gobin\gopkg.in\src-d\go-kallax.v1\@v\v1.3.5\generator\cli\kallax\kallax.exe\E'$'
+! stderr .+
+
+[linux]   exec $HOME/.cache/gobin/gopkg.in/src-d/go-kallax.v1/@v/v1.3.5/generator/cli/kallax/kallax
+[darwin]  exec $HOME/Library/Caches/gobin/gopkg.in/src-d/go-kallax.v1/@v/v1.3.5/generator/cli/kallax/kallax
+[windows] exec $LOCALAPPDATA/gobin/gopkg.in\src-d\go-kallax.v1\@v\v1.3.5\generator\cli\kallax\kallax.exe
+stdout '^This is kallax$'
+! stderr .+

--- a/testdata/mod/gopkg.in_src-d_go-kallax.v1_v1.3.5.txt
+++ b/testdata/mod/gopkg.in_src-d_go-kallax.v1_v1.3.5.txt
@@ -1,0 +1,15 @@
+module gopkg.in/src-d/go-kallax.v1@v1.3.5
+
+-- .mod --
+module gopkg.in/src-d/go-kallax.v1
+-- .info --
+{"Version":"v1.3.5","Time":"2018-06-07T08:58:58Z"}
+
+-- generator/cli/kallax/main.go --
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("This is kallax")
+}

--- a/testdata/print-global-non-module.txt
+++ b/testdata/print-global-non-module.txt
@@ -1,11 +1,11 @@
 gobin -p github.com/gobin-testrepos/non-module@v1.0.0
-[linux]   stdout ^$HOME\Q/.cache/gobin/github.com/gobin-testrepos/non-module/@v/v1.0.0/github.com/gobin-testrepos/non-module/non-module\E'$'
-[darwin]  stdout ^$HOME\Q/Library/Caches/gobin/github.com/gobin-testrepos/non-module/@v/v1.0.0/github.com/gobin-testrepos/non-module/non-module\E'$'
-[windows] stdout ^${LOCALAPPDATA@R}\Q\gobin\github.com\gobin-testrepos\non-module\@v\v1.0.0\github.com\gobin-testrepos\non-module\non-module.exe\E'$'
+[linux]   stdout ^$HOME\Q/.cache/gobin/github.com/gobin-testrepos/non-module/@v/v1.0.0/non-module\E'$'
+[darwin]  stdout ^$HOME\Q/Library/Caches/gobin/github.com/gobin-testrepos/non-module/@v/v1.0.0/non-module\E'$'
+[windows] stdout ^${LOCALAPPDATA@R}\Q\gobin\github.com\gobin-testrepos\non-module\@v\v1.0.0\non-module.exe\E'$'
 ! stderr .+
 
-[linux]   exec $HOME/.cache/gobin/github.com/gobin-testrepos/non-module/@v/v1.0.0/github.com/gobin-testrepos/non-module/non-module
-[darwin]  exec $HOME/Library/Caches/gobin/github.com/gobin-testrepos/non-module/@v/v1.0.0/github.com/gobin-testrepos/non-module/non-module
-[windows] exec $LOCALAPPDATA\gobin\github.com\gobin-testrepos\non-module\@v\v1.0.0\github.com\gobin-testrepos\non-module\non-module.exe
+[linux]   exec $HOME/.cache/gobin/github.com/gobin-testrepos/non-module/@v/v1.0.0/non-module
+[darwin]  exec $HOME/Library/Caches/gobin/github.com/gobin-testrepos/non-module/@v/v1.0.0/non-module
+[windows] exec $LOCALAPPDATA\gobin\github.com\gobin-testrepos\non-module\@v\v1.0.0\non-module.exe
 stdout '^I am not a module$'
 ! stderr .+

--- a/testdata/print-global-simple-main.txt
+++ b/testdata/print-global-simple-main.txt
@@ -1,11 +1,11 @@
 gobin -p github.com/gobin-testrepos/simple-main@v1.0.0
-[linux]   stdout ^$HOME\Q/.cache/gobin/github.com/gobin-testrepos/simple-main/@v/v1.0.0/github.com/gobin-testrepos/simple-main/simple-main\E'$'
-[darwin]  stdout ^$HOME\Q/Library/Caches/gobin/github.com/gobin-testrepos/simple-main/@v/v1.0.0/github.com/gobin-testrepos/simple-main/simple-main\E'$'
-[windows] stdout ^${LOCALAPPDATA@R}\Q\gobin\github.com\gobin-testrepos\simple-main\@v\v1.0.0\github.com\gobin-testrepos\simple-main\simple-main.exe\E'$'
+[linux]   stdout ^$HOME\Q/.cache/gobin/github.com/gobin-testrepos/simple-main/@v/v1.0.0/simple-main\E'$'
+[darwin]  stdout ^$HOME\Q/Library/Caches/gobin/github.com/gobin-testrepos/simple-main/@v/v1.0.0/simple-main\E'$'
+[windows] stdout ^${LOCALAPPDATA@R}\Q\gobin\github.com\gobin-testrepos\simple-main\@v\v1.0.0\simple-main.exe\E'$'
 ! stderr .+
 
-[linux]   exec $HOME/.cache/gobin/github.com/gobin-testrepos/simple-main/@v/v1.0.0/github.com/gobin-testrepos/simple-main/simple-main
-[darwin]  exec $HOME/Library/Caches/gobin/github.com/gobin-testrepos/simple-main/@v/v1.0.0/github.com/gobin-testrepos/simple-main/simple-main
-[windows] exec $LOCALAPPDATA/gobin/github.com/gobin-testrepos/simple-main/@v/v1.0.0/github.com/gobin-testrepos/simple-main/simple-main.exe
+[linux]   exec $HOME/.cache/gobin/github.com/gobin-testrepos/simple-main/@v/v1.0.0/simple-main
+[darwin]  exec $HOME/Library/Caches/gobin/github.com/gobin-testrepos/simple-main/@v/v1.0.0/simple-main
+[windows] exec $LOCALAPPDATA/gobin/github.com/gobin-testrepos/simple-main/@v/v1.0.0/simple-main.exe
 stdout '^Simple module-based main v1.0.0$'
 ! stderr .+

--- a/testdata/print-main-module-non-module.txt
+++ b/testdata/print-main-module-non-module.txt
@@ -1,10 +1,9 @@
 cd repo
 gobin -m -p github.com/gobin-testrepos/non-module
-[!windows] stdout ^${WORK@R}\Q/repo/.gobincache/github.com/gobin-testrepos/non-module/@v/v1.0.0/github.com/gobin-testrepos/non-module/non-module\E'$'
-[windows]  stdout ^${WORK@R}\Q\repo\.gobincache\github.com\gobin-testrepos\non-module\@v\v1.0.0\github.com\gobin-testrepos\non-module\non-module.exe\E'$'
+stdout ^${WORK@R}[/\\]repo[/\\].gobincache[/\\]github.com[/\\]gobin-testrepos[/\\]non-module[/\\]@v[/\\]v1.0.0[/\\]non-module$exe'$'
 ! stderr .+
 
-exec $WORK/repo/.gobincache/github.com/gobin-testrepos/non-module/@v/v1.0.0/github.com/gobin-testrepos/non-module/non-module$exe
+exec $WORK/repo/.gobincache/github.com/gobin-testrepos/non-module/@v/v1.0.0/non-module$exe
 stdout '^I am not a module$'
 ! stderr .+
 

--- a/testdata/print-main-module-simple-main.txt
+++ b/testdata/print-main-module-simple-main.txt
@@ -1,10 +1,9 @@
 cd repo
 gobin -m -p github.com/gobin-testrepos/simple-main
-[!windows] stdout ^${WORK@R}\Q/repo/.gobincache/github.com/gobin-testrepos/simple-main/@v/v1.0.0/github.com/gobin-testrepos/simple-main/simple-main\E'$'
-[windows]  stdout ^${WORK@R}\Q\repo\.gobincache\github.com\gobin-testrepos\simple-main\@v\v1.0.0\github.com\gobin-testrepos\simple-main\simple-main.exe\E'$'
+stdout ^${WORK@R}[/\\]repo[/\\].gobincache[/\\]github.com[/\\]gobin-testrepos[/\\]simple-main[/\\]@v[/\\]v1.0.0[/\\]simple-main$exe'$'
 ! stderr .+
 
-exec $WORK/repo/.gobincache/github.com/gobin-testrepos/simple-main/@v/v1.0.0/github.com/gobin-testrepos/simple-main/simple-main$exe
+exec $WORK/repo/.gobincache/github.com/gobin-testrepos/simple-main/@v/v1.0.0/simple-main$exe
 stdout '^Simple module-based main v1.0.0$'
 ! stderr .+
 


### PR DESCRIPTION
Also fix a bug whereby the full import path was being used after the
module path for locations within the cache.

Fixes #65.