### PR TITLE
Strip out an directory-based replacements from main pkg's module

### DIFF
--- a/testdata/mod/github.com_gobin-testrepos_simple-main-directory-replace_v1.0.0.txt
+++ b/testdata/mod/github.com_gobin-testrepos_simple-main-directory-replace_v1.0.0.txt
@@ -1,0 +1,27 @@
+-- .mod --
+module github.com/gobin-testrepos/simple-main-directory-replace
+
+require github.com/gobin-testrepos/food v1.0.0
+
+replace github.com/gobin-testrepos/food => /road/to/nowhere
+-- .info --
+{"Version":"v1.0.0","Time":"2018-10-22T18:45:39Z"}
+
+-- go.mod --
+module github.com/gobin-testrepos/simple-main-directory-replace
+
+require github.com/gobin-testrepos/food v1.0.0
+
+replace github.com/gobin-testrepos/food => /road/to/nowhere
+
+-- main.go --
+package main
+
+import "fmt"
+
+import "github.com/gobin-testrepos/food"
+
+func main() {
+	fmt.Println("Simple module-based main v1.0.0")
+	fmt.Printf("Today we will eat %v\n", food.MainCourse)
+}

--- a/testdata/replace_directory.txt
+++ b/testdata/replace_directory.txt
@@ -1,0 +1,7 @@
+# Verify that directory-target replace statements in the main package's module
+# are ignored.
+
+env HOME=$WORK/home
+gobin -run github.com/gobin-testrepos/simple-main-directory-replace@v1.0.0
+stdout '^Simple module-based main v1.0.0$'
+stdout '^Today we will eat fish$'


### PR DESCRIPTION
Per much previous discussion, we do apply replace directives in the main
package's module. But for directory replacements this is not guaranteed
to make sense. Indeed it almost certainly doesn't make sense most of the
time. Therefore, strip out these replace directives, leaving behind the
versioned, non-directory replaces.