### PR TITLE
main: optimise "runtime" steps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,13 @@ cache:
   - $GOPATH/pkg/mod/cache
 
 go:
-  - "1.11.12"
-  - "1.12.7"
+  - "1.11.13"
+  - "1.12.9"
   - "1.13beta1"
+
+branches:
+  only:
+    - master
 
 os:
   - linux

--- a/_scripts/known_diffs/go1.11.13/badly_sorted_vendor_modules.txt.diff
+++ b/_scripts/known_diffs/go1.11.13/badly_sorted_vendor_modules.txt.diff
@@ -1,9 +1,9 @@
 diff --git b/vendor/modules.txt a/vendor/modules.txt
-index 49894ad..5b8d57c 100644
+index 01abe41..ebc5500 100644
 --- b/vendor/modules.txt
 +++ a/vendor/modules.txt
 @@ -1,16 +1,16 @@
- # github.com/rogpeppe/go-internal v1.3.0
+ # github.com/rogpeppe/go-internal v1.3.1
  github.com/rogpeppe/go-internal/cmd/txtar-addmod
 -github.com/rogpeppe/go-internal/module
 -github.com/rogpeppe/go-internal/txtar

--- a/_scripts/known_diffs/go1.12.9/badly_sorted_vendor_modules.txt.diff
+++ b/_scripts/known_diffs/go1.12.9/badly_sorted_vendor_modules.txt.diff
@@ -1,9 +1,9 @@
 diff --git b/vendor/modules.txt a/vendor/modules.txt
-index 49894ad..5b8d57c 100644
+index 01abe41..ebc5500 100644
 --- b/vendor/modules.txt
 +++ a/vendor/modules.txt
 @@ -1,16 +1,16 @@
- # github.com/rogpeppe/go-internal v1.3.0
+ # github.com/rogpeppe/go-internal v1.3.1
  github.com/rogpeppe/go-internal/cmd/txtar-addmod
 -github.com/rogpeppe/go-internal/module
 -github.com/rogpeppe/go-internal/txtar

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/myitcv/gobin
 
-require github.com/rogpeppe/go-internal v1.3.0
+require github.com/rogpeppe/go-internal v1.3.1
 
 go 1.11

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/rogpeppe/go-internal v1.3.0 h1:RR9dF3JtopPvtkroDZuVD7qquD0bnHlKSqaQhgwt8yk=
-github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rogpeppe/go-internal v1.3.1 h1:pgz0lCb+F99TrCwoy7d83j5kI//45fBQ34KzZ7t5as0=
+github.com/rogpeppe/go-internal v1.3.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0 h1:0vLT13EuvQ0hNvakwLuFZ/jYrLp5F3kcWHXdRggjCE8=

--- a/vendor/github.com/rogpeppe/go-internal/goproxytest/proxy.go
+++ b/vendor/github.com/rogpeppe/go-internal/goproxytest/proxy.go
@@ -193,8 +193,13 @@ func (srv *Server) handler(w http.ResponseWriter, r *http.Request) {
 
 	a := srv.readArchive(path, vers)
 	if a == nil {
+		// As of https://go-review.googlesource.com/c/go/+/189517, cmd/go
+		// resolves all paths. i.e. for github.com/hello/world, cmd/go attempts
+		// to resolve github.com, github.com/hello and github.com/hello/world.
+		// cmd/go expects a 404/410 response if there is nothing there. Hence we
+		// cannot return with a 500.
 		fmt.Fprintf(os.Stderr, "go proxy: no archive %s %s\n", path, vers)
-		http.Error(w, "cannot load archive", 500)
+		http.NotFound(w, r)
 		return
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/rogpeppe/go-internal v1.3.0
+# github.com/rogpeppe/go-internal v1.3.1
 github.com/rogpeppe/go-internal/cmd/txtar-addmod
 github.com/rogpeppe/go-internal/goproxytest
 github.com/rogpeppe/go-internal/gotooltest


### PR DESCRIPTION
gobin maintains binaries in its own cache. The key for a cache entry is
a function of main package path, version and build tags. Assuming nobody
tampers with the build cache (making it readonly is the subject of #5),
then we need only install to the cache entry if a file does not already
exist.

Also, optimise go list calls by using -find; we don't care for the
dependencies in these steps.

No change in tests because their should be no change in behaviour.

With some incredibly unscientific timing tests on my machine, this
reduces the time taken for "gobin -run github.com/myitcv/gobin -help"
from 0.636s to 0.246s. "gobin -help" times at 0.070s which means ~0.176s
of gobin "overhead".