### PR TITLE
main: fix bug with major version >= 2 being installed to wrong target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ os:
 matrix:
   include:
     - os: linux
-      go: "1.11.x"
+      go: "1.13beta1"
       env: CHECK_GOFMT=1
 
 env:

--- a/main.go
+++ b/main.go
@@ -360,21 +360,9 @@ func mainerr() error {
 				gobin = filepath.Join(gobinCache, fmt.Sprintf("%x", h.Sum(nil)))
 			}
 
-			var base string
-			if mp.Module.Path == mp.ImportPath {
-				pref, _, ok := module.SplitPathVersion(mp.ImportPath)
-				if !ok {
-					return fmt.Errorf("failed to derive non-version prefix from %v", mp.ImportPath)
-				}
-				base = path.Base(pref)
-			} else {
-				base = path.Base(mp.ImportPath)
-			}
+			// mp.Target already has .exe for Windows
+			base := filepath.Base(mp.Target)
 			target := filepath.Join(gobin, base)
-
-			if runtime.GOOS == "windows" {
-				target += ".exe"
-			}
 
 			// optimistically remove our target in case we are installing over self
 			// TODO work out what to do for Windows
@@ -406,7 +394,7 @@ func mainerr() error {
 				fmt.Printf("%v %v\n", mp.Module.Path, mp.Module.Version)
 			case *fRun:
 				run := exec.Command(target, runArgs...)
-				run.Args[0] = path.Base(mp.ImportPath)
+				run.Args[0] = filepath.Base(mp.Target)
 				run.Stdin = os.Stdin
 				run.Stdout = os.Stdout
 				run.Stderr = os.Stderr
@@ -430,12 +418,8 @@ func mainerr() error {
 					return fmt.Errorf("failed to open %v: %v", target, err)
 				}
 				defer src.Close()
-				bin := filepath.Join(installBin, path.Base(mp.ImportPath))
 
-				if runtime.GOOS == "windows" {
-					bin += ".exe"
-				}
-
+				bin := filepath.Join(installBin, filepath.Base(mp.Target))
 				openMode := os.O_CREATE | os.O_WRONLY
 
 				// optimistically remove our target in case we are installing over self
@@ -466,6 +450,7 @@ type listPkg struct {
 	ImportPath string
 	Name       string
 	Dir        string
+	Target     string
 	Module     struct {
 		Path    string
 		Dir     string

--- a/testdata/major_version.txt
+++ b/testdata/major_version.txt
@@ -2,6 +2,10 @@
 # at the end of the main package path that we end up with
 # the right binary name
 
+gobin example.com/good/v2
+stdout '^Installed example\.com/good/v2@v2\.0\.0 to '${WORK@R}'[/\\]gopath[/\\]bin[/\\]good'$exe$
+! stderr .+
+
 gobin -p example.com/good/v2
 stdout [/\\]good$exe$
 ! stderr .+

--- a/testdata/run.txt
+++ b/testdata/run.txt
@@ -4,7 +4,7 @@
 # attached
 stdin input
 gobin -m -run example.com/blah
-cmp stdout output.golden
+cmpenv stdout output.golden
 
 -- go.mod --
 module example.com/blah
@@ -27,5 +27,5 @@ func main() {
 -- input --
 This is stdin
 -- output.golden --
-blah
+blah$exe
 This is stdin


### PR DESCRIPTION
We previously had a test that ensure the cache path of a major package
>= 2 was correct, but this failed to ensure the installed binary had the
right target name.

Fix the test and fix the bug.

Fixes #82