### PR TITLE
main: fix -m mode stale binary bug

### DIFF
--- a/testdata/main-module-change.txt
+++ b/testdata/main-module-change.txt
@@ -1,0 +1,36 @@
+# Specifically test the logic that ensures -m packages are always
+# installed. Per the code comment, we always install as a means of
+# establishing whether the target is current. If we instead chose
+# to perform these checks ourself, we'd do just the same amount of
+# work.
+
+# Before
+cp msg.go.before msg.go
+gobin -m -run .
+stdout ^before$
+! stderr .+
+
+# After
+cp msg.go.after msg.go
+gobin -m -run .
+stdout ^after$
+! stderr .+
+
+-- go.mod --
+module mod.com
+-- main.go --
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println(msg)
+}
+-- msg.go.before --
+package main
+
+var msg = "before"
+-- msg.go.after --
+package main
+
+var msg = "after"


### PR DESCRIPTION
In 6038506 we incorrectly optimised away an install step when -m is
supplied. We must always install if we are in -m mode, because the main
module is responsible for resolving versions. We therefore utilise the
install step to effectively ensure the target binary is up to date.

This logic would change if were to adopt #81 because we would then only
install non-versioned module packages (i.e. non-main module,
non-directory replaced), or in the case a versioned target does not
exist in the gobin cache.