### PR TITLE
main: only use local cache on install for -nonet

### DIFF
--- a/main.go
+++ b/main.go
@@ -401,7 +401,11 @@ func mainerr() error {
 				}
 				installCmd.Args = append(installCmd.Args, mp.ImportPath)
 				installCmd.Dir = pkg.wd
-				installCmd.Env = append(buildEnv(localCacheProxy), "GOBIN="+gobin)
+				proxy := ""
+				if *fNoNet {
+					proxy = localCacheProxy
+				}
+				installCmd.Env = append(buildEnv(proxy), "GOBIN="+gobin)
 				if err := installCmd.run(); err != nil {
 					return err
 				}


### PR DESCRIPTION
Using the local module cache for installs unconditionally means that
there will be situations where that cache is incomplete and hence the
install (and any subsequent step) will fail.

Rather we only need to enforce the use of the local module cache when we
are in -nonet.

Hence we now allow network access in the case of a module cache miss in
the non-nonet situation, which is exactly the semantics we intend.

Test to follow.

Fixes #86